### PR TITLE
refactor: simplify and refactor nix flake tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,8 @@
 name = "chroma"
 version = "0.1.0"
 edition = "2021"
-authors = ["user <email>"]
 description = "🌈 Shader-based audio visualizer for the terminal."
-license = "MIT"
+license = "GPL-3.0-only"
 repository = "https://github.com/yuri-xyz/chroma"
 
 [dependencies]

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777268161,
@@ -18,6 +36,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -39,6 +58,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,10 @@
             // {
               pname = "chroma-test";
               doCheck = true;
-              cargoTestCommand = "cargo test --all-targets --offline --frozen";
+              cargoTestFlags = [
+                "--all-targets"
+                "--frozen"
+              ];
               installPhase = "touch $out";
             }
           );
@@ -155,7 +158,11 @@
             // {
               pname = "chroma-clippy";
               doCheck = false;
-              cargoBuildCommand = "cargo clippy --all-targets --offline --frozen -- -D warnings";
+              buildPhase = ''
+                runHook preBuild
+                cargo clippy --all-targets --offline --frozen -- -D warnings
+                runHook postBuild
+              '';
               installPhase = "touch $out";
             }
           );

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "Chroma - GPU-accelerated ASCII art audio visualizer for the terminal";
 
   inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -11,97 +12,94 @@
 
   outputs =
     {
+      flake-utils,
       nixpkgs,
       rust-overlay,
       ...
     }:
-    let
-      supportedSystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
 
-      perSystem =
-        system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ rust-overlay.overlays.default ];
-          };
+        inherit (pkgs) lib;
 
-          inherit (pkgs) lib;
+        # Keep these pins explicit. The package build uses stable Rust while
+        # the dev shell uses nightly rustfmt for rustfmt.toml's unstable
+        # import-grouping options.
+        packageRustVersion = "1.95.0";
+        devNightlyDate = "2026-04-29";
 
-          # Keep these pins explicit. The package build uses stable Rust while
-          # the dev shell uses nightly rustfmt for rustfmt.toml's unstable
-          # import-grouping options.
-          packageRustVersion = "1.95.0";
-          devNightlyDate = "2026-04-29";
-
-          rustToolchain = pkgs.rust-bin.stable.${packageRustVersion}.default;
-          clippyToolchain = pkgs.rust-bin.stable.${packageRustVersion}.default.override {
-            extensions = [ "clippy" ];
-          };
-          devRustToolchain = pkgs.rust-bin.nightly.${devNightlyDate}.default.override {
-            extensions = [
-              "rust-src"
-              "rustfmt"
-              "clippy"
-            ];
-          };
-          rustPlatform = pkgs.makeRustPlatform {
-            cargo = rustToolchain;
-            rustc = rustToolchain;
-          };
-          clippyRustPlatform = pkgs.makeRustPlatform {
-            cargo = clippyToolchain;
-            rustc = clippyToolchain;
-          };
-
-          src = lib.cleanSourceWith {
-            name = "chroma-source";
-            src = ./.;
-            filter =
-              path: type:
-              let
-                baseName = baseNameOf path;
-              in
-              lib.cleanSourceFilter path type
-              && !(
-                type == "directory"
-                && lib.elem baseName [
-                  "target"
-                  ".direnv"
-                  ".devenv"
-                ]
-              );
-          };
-
-          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-          version = cargoToml.package.version;
-
-          runtimeLibraries = [
-            pkgs.vulkan-loader
-            pkgs.alsa-lib
-            pkgs.libpulseaudio
+        rustToolchain = pkgs.rust-bin.stable.${packageRustVersion}.default;
+        clippyToolchain = pkgs.rust-bin.stable.${packageRustVersion}.default.override {
+          extensions = [ "clippy" ];
+        };
+        devRustToolchain = pkgs.rust-bin.nightly.${devNightlyDate}.default.override {
+          extensions = [
+            "rust-src"
+            "rustfmt"
+            "clippy"
           ];
-          runtimeLibraryPath = lib.makeLibraryPath runtimeLibraries;
+        };
 
-          commonNativeBuildInputs = [
-            pkgs.pkg-config
-          ];
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+        clippyRustPlatform = pkgs.makeRustPlatform {
+          cargo = clippyToolchain;
+          rustc = clippyToolchain;
+        };
 
-          chroma = rustPlatform.buildRustPackage {
-            pname = "chroma";
-            inherit src version;
+        src = lib.cleanSourceWith {
+          name = "chroma-source";
+          src = ./.;
+          filter =
+            path: type:
+            let
+              baseName = baseNameOf path;
+            in
+            lib.cleanSourceFilter path type
+            && !(
+              type == "directory"
+              && lib.elem baseName [
+                "target"
+                ".direnv"
+                ".devenv"
+              ]
+            );
+        };
 
-            cargoLock.lockFile = ./Cargo.lock;
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        version = cargoToml.package.version;
 
-            strictDeps = true;
-            nativeBuildInputs = commonNativeBuildInputs ++ [
+        runtimeLibraries = [
+          pkgs.vulkan-loader
+          pkgs.alsa-lib
+          pkgs.libpulseaudio
+        ];
+        runtimeLibraryPath = lib.makeLibraryPath runtimeLibraries;
+
+        commonRustBuildArgs = {
+          pname = "chroma";
+          inherit src version;
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          strictDeps = true;
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = runtimeLibraries;
+        };
+
+        chroma = rustPlatform.buildRustPackage (
+          commonRustBuildArgs
+          // {
+            nativeBuildInputs = commonRustBuildArgs.nativeBuildInputs ++ [
               pkgs.makeWrapper
             ];
-            buildInputs = runtimeLibraries;
 
             # The default package build stays focused on producing the binary.
             # The flake checks below expose fmt, tests, clippy, and workflow
@@ -110,119 +108,100 @@
 
             postInstall = ''
               wrapProgram "$out/bin/chroma" \
-                --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
+                --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}" \
+                --set-default WGPU_BACKEND vulkan
             '';
 
             meta = {
               description = "Rust-based ASCII art shader audio visualizer for the terminal";
               homepage = "https://github.com/yuri-xyz/chroma";
-              license = lib.licenses.mit;
+              license = lib.licenses.gpl3Only;
               mainProgram = "chroma";
               platforms = lib.platforms.linux;
             };
-          };
+          }
+        );
 
-          mkApp = drv: {
-            type = "app";
-            program = lib.getExe drv;
-            meta.description = "Run Chroma with audio support";
-          };
-
-          mkCargoCheck =
-            checkRustPlatform: name: command:
-            checkRustPlatform.buildRustPackage {
-              pname = "chroma-${name}";
-              inherit src version;
-
-              cargoLock.lockFile = ./Cargo.lock;
-
-              strictDeps = true;
-              nativeBuildInputs = commonNativeBuildInputs;
-              buildInputs = runtimeLibraries;
-
-              buildPhase = ''
-                runHook preBuild
-                ${command}
-                runHook postBuild
-              '';
-              doCheck = false;
-              installPhase = ''
-                runHook preInstall
-                touch "$out"
-                runHook postInstall
-              '';
-            };
-        in
-        rec {
-          packages = {
-            inherit chroma;
-            default = chroma;
-          };
-
-          apps = {
-            chroma = mkApp chroma;
-            default = apps.chroma;
-          };
-
-          checks = {
-            package = chroma;
-            test = mkCargoCheck rustPlatform "test" "cargo test --all-targets --offline --frozen";
-            clippy =
-              mkCargoCheck clippyRustPlatform "clippy"
-                "cargo clippy --all-targets --offline --frozen -- -D warnings";
-            fmt = pkgs.runCommand "chroma-fmt-check" { nativeBuildInputs = [ devRustToolchain ]; } ''
-              cd ${src}
-              cargo fmt --all -- --check
-              touch "$out"
-            '';
-            actionlint =
-              pkgs.runCommand "chroma-actionlint-check" { nativeBuildInputs = [ pkgs.actionlint ]; }
-                ''
-                  actionlint -color ${src}/.github/workflows/*.yml
-                  touch "$out"
-                '';
-            nixfmt = pkgs.runCommand "chroma-nixfmt-check" { nativeBuildInputs = [ pkgs.nixfmt ]; } ''
-              nixfmt --check ${./flake.nix}
-              touch "$out"
-            '';
-          };
-
-          formatter = pkgs.nixfmt;
-
-          devShells.default = pkgs.mkShell {
-            packages = [
-              devRustToolchain
-              pkgs.rust-analyzer
-              pkgs.actionlint
-              pkgs.nixfmt
-              pkgs.pkg-config
-              pkgs.vulkan-loader
-              pkgs.vulkan-tools
-              pkgs.alsa-lib
-              pkgs.libpulseaudio
-              pkgs.pipewire
-            ];
-
-            LD_LIBRARY_PATH = runtimeLibraryPath;
-            WGPU_BACKEND = "vulkan";
-
-            shellHook = ''
-              echo "Chroma dev shell"
-              echo "  cargo run"
-              echo "  cargo fmt --all -- --check"
-              echo "  cargo test"
-              echo "  cargo clippy --all-targets -- -D warnings"
-              echo "  actionlint -color"
-              echo "  nix flake check"
-            '';
-          };
+        mkApp = drv: {
+          type = "app";
+          program = lib.getExe drv;
+          meta.description = "Run Chroma with audio support";
         };
-    in
-    {
-      packages = forAllSystems (system: (perSystem system).packages);
-      apps = forAllSystems (system: (perSystem system).apps);
-      checks = forAllSystems (system: (perSystem system).checks);
-      formatter = forAllSystems (system: (perSystem system).formatter);
-      devShells = forAllSystems (system: (perSystem system).devShells);
-    };
+      in
+      rec {
+        packages = {
+          inherit chroma;
+          default = chroma;
+        };
+
+        apps = {
+          chroma = mkApp chroma;
+          default = apps.chroma;
+        };
+
+        checks = {
+          package = chroma;
+          test = rustPlatform.buildRustPackage (
+            commonRustBuildArgs
+            // {
+              pname = "chroma-test";
+              doCheck = true;
+              cargoTestCommand = "cargo test --all-targets --offline --frozen";
+              installPhase = "touch $out";
+            }
+          );
+          clippy = clippyRustPlatform.buildRustPackage (
+            commonRustBuildArgs
+            // {
+              pname = "chroma-clippy";
+              doCheck = false;
+              cargoBuildCommand = "cargo clippy --all-targets --offline --frozen -- -D warnings";
+              installPhase = "touch $out";
+            }
+          );
+          fmt = pkgs.runCommand "chroma-fmt-check" { nativeBuildInputs = [ devRustToolchain ]; } ''
+            cd ${src}
+            cargo fmt --all -- --check
+            touch "$out"
+          '';
+          actionlint =
+            pkgs.runCommand "chroma-actionlint-check" { nativeBuildInputs = [ pkgs.actionlint ]; }
+              ''
+                actionlint -color ${src}/.github/workflows/*.yml
+                touch "$out"
+              '';
+          nixfmt = pkgs.runCommand "chroma-nixfmt-check" { nativeBuildInputs = [ pkgs.nixfmt ]; } ''
+            nixfmt --check ${./flake.nix}
+            touch "$out"
+          '';
+        };
+
+        formatter = pkgs.nixfmt;
+
+        devShells.default = pkgs.mkShell {
+          packages = runtimeLibraries ++ [
+            devRustToolchain
+            pkgs.rust-analyzer
+            pkgs.actionlint
+            pkgs.nixfmt
+            pkgs.pkg-config
+            pkgs.vulkan-tools
+            pkgs.pipewire
+          ];
+
+          LD_LIBRARY_PATH = runtimeLibraryPath;
+          WGPU_BACKEND = "vulkan";
+
+          shellHook = ''
+            echo "Chroma dev shell"
+            echo "  cargo run"
+            echo "  cargo fmt --all -- --check"
+            echo "  cargo test"
+            echo "  cargo clippy --all-targets -- -D warnings"
+            echo "  actionlint -color"
+            echo "  nix flake check"
+          '';
+        };
+      }
+    );
 }


### PR DESCRIPTION
Resolves #8. Adds general improvements to the Nix flake and it's tooling:

- Enact `flake-utils` to clean system-specific boilerplate.

- Correct license information (is GPL-3.0, had MIT) in the flake and the Cargo specification.

- Weave toolkit information and usage of `buildRustPackage` together to reduce toolkit fragmentation.

- Condense some dependency calls to reduce repetition.

- Replace implementation and calls of `mkCargoCheck` helper with calls of `buildRustPackage`.

- Drop placeholder `authors` field from the Cargo specification.