### PR TITLE
feat: add gravity with capped mouse fight

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Stream mode skips terminal setup, the status bar, and interactive input. By defa
 - `→`/`←` - Adjust speed
 - `+`/`-` - Adjust amplitude
 - `[`/`]` - Adjust scale
+- `g`/`G` - Adjust gravity (mouse fights gravity but cannot overpower it)
 
 See [CONTROLS.md](./notes/CONTROLS.md) and [PALETTES.md](./notes/PALETTES.md) for more details.
 

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,7 @@ fn main() {
     // Effects and main entry point
     "src/shader_common/effects.wgsl",
     "src/shader_common/beat_distortion.wgsl",
+    "src/shader_common/gravity.wgsl",
     "src/shader_common/main.wgsl",
   ];
 

--- a/examples/custom_shader.wgsl
+++ b/examples/custom_shader.wgsl
@@ -33,6 +33,10 @@ struct Uniforms {
     beat_distortion_time: f32,
     beat_distortion_strength: f32,
     beat_zoom_strength: f32,
+    gravity: f32,
+    gravity_offset: vec2<f32>,
+    mouse_position: vec2<f32>,
+    mouse_influence: f32,
     background_tint: vec3<f32>,
 }
 

--- a/notes/CONTROLS.md
+++ b/notes/CONTROLS.md
@@ -56,6 +56,14 @@ Save the current configuration to a file in the working directory.
 - Range: 0.1 → 5.0
 - Effect: Change pattern size
 
+### Gravity
+
+- `g` - Increase gravity (+0.1)
+- `G` - Decrease gravity (-0.1)
+- Range: 0.0 → 2.0
+- Effect: Pulls the pattern downward. Mouse movement/click fights the fall but cannot cancel it (capped at 75% of gravity).
+- CLI: `--gravity FLOAT`, `--mouse-fight FLOAT`
+
 ### Pattern Type
 
 - `T` - Next pattern

--- a/notes/USAGE.md
+++ b/notes/USAGE.md
@@ -55,6 +55,15 @@ Controls the zoom level of the shader pattern.
 - Default: 1.0
 - Effect: Lower values zoom in, higher values zoom out
 
+### Gravity
+
+Controls downward pattern scroll. Default is off (`0.0`).
+
+- Range: 0.0 to 2.0
+- CLI: `--gravity FLOAT`, `--mouse-fight FLOAT`
+- Keys: `g` / `G`
+- Mouse movement and click fight the fall but cannot cancel it (capped below full gravity). Interactive sessions enable mouse capture so live gravity adjustments can receive pointer input.
+
 ## ASCII Palettes
 
 The application supports multiple ASCII palettes:

--- a/src/app/gravity.rs
+++ b/src/app/gravity.rs
@@ -1,0 +1,249 @@
+//! Downward gravity for the shader UV plane, with mouse input that can fight
+//! the fall but never cancel it completely.
+
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Max fraction of gravity acceleration the mouse may cancel (must stay < 1).
+const MOUSE_FIGHT_CAP: f32 = 0.75;
+/// UV units / s² per unit of the `gravity` parameter.
+const GRAVITY_ACCEL_SCALE: f32 = 0.45;
+/// Horizontal pull toward the mouse cursor (scaled by gravity).
+const HORIZONTAL_PULL: f32 = 0.55;
+/// Velocity damping per second (exponential decay coefficient).
+const DAMPING: f32 = 2.4;
+/// Soft speed clamp in UV units / s.
+const MAX_SPEED: f32 = 1.25;
+/// How long after last mouse event the cursor still counts as active.
+const MOUSE_ACTIVE_SECONDS: f32 = 1.25;
+
+#[derive(Debug, Clone)]
+pub struct GravityState {
+  pub offset: [f32; 2],
+  pub velocity: [f32; 2],
+  pub mouse: [f32; 2],
+  pub mouse_active: bool,
+  pub mouse_pressed: bool,
+  mouse_active_remaining: f32,
+}
+
+impl Default for GravityState {
+  fn default() -> Self {
+    Self {
+      offset: [0.0, 0.0],
+      velocity: [0.0, 0.0],
+      mouse: [0.5, 0.5],
+      mouse_active: false,
+      mouse_pressed: false,
+      mouse_active_remaining: 0.0,
+    }
+  }
+}
+
+impl GravityState {
+  pub fn set_mouse_position(&mut self, x: f32, y: f32) {
+    self.mouse = [x.clamp(0.0, 1.0), y.clamp(0.0, 1.0)];
+    self.mouse_active = true;
+    self.mouse_active_remaining = MOUSE_ACTIVE_SECONDS;
+  }
+
+  pub fn set_mouse_pressed(&mut self, pressed: bool) {
+    self.mouse_pressed = pressed;
+    if pressed {
+      self.mouse_active = true;
+      self.mouse_active_remaining = MOUSE_ACTIVE_SECONDS;
+    }
+  }
+
+  /// Effective mouse influence sent to the shader (0 = idle).
+  pub fn shader_mouse_influence(&self, mouse_fight: f32) -> f32 {
+    if !self.mouse_active {
+      return 0.0;
+    }
+
+    let base = mouse_fight.clamp(0.0, 1.0) * MOUSE_FIGHT_CAP;
+    if self.mouse_pressed {
+      base
+    } else {
+      base * 0.65
+    }
+  }
+
+  /// Integrate gravity and mouse forces for one frame.
+  ///
+  /// Mouse vertical lift is hard-capped so net downward acceleration never
+  /// drops below `gravity_accel * (1 - MOUSE_FIGHT_CAP)`.
+  pub fn update(&mut self, gravity: f32, mouse_fight: f32, delta_time: f32) {
+    let dt = delta_time.clamp(0.0, 0.1);
+
+    if self.mouse_active_remaining > 0.0 {
+      self.mouse_active_remaining = (self.mouse_active_remaining - dt).max(0.0);
+      if self.mouse_active_remaining <= 0.0 && !self.mouse_pressed {
+        self.mouse_active = false;
+      }
+    }
+
+    let gravity = gravity.max(0.0);
+    if gravity <= 0.0001 {
+      // Ease residual motion back to rest when gravity is off.
+      self.velocity[0] *= (-DAMPING * dt).exp();
+      self.velocity[1] *= (-DAMPING * dt).exp();
+      self.offset[0] += self.velocity[0] * dt;
+      self.offset[1] += self.velocity[1] * dt;
+      return;
+    }
+
+    let mut accel_x = 0.0;
+    let accel_y = net_vertical_accel(
+      gravity,
+      mouse_fight,
+      self.mouse_active,
+      self.mouse_pressed,
+    );
+
+    if self.mouse_active {
+      let press_boost = if self.mouse_pressed { 1.0 } else { 0.65 };
+      // Horizontal tug toward the cursor; strength scales with gravity.
+      accel_x += (self.mouse[0] - 0.5) * HORIZONTAL_PULL * gravity * press_boost;
+    }
+
+    self.velocity[0] += accel_x * dt;
+    self.velocity[1] += accel_y * dt;
+
+    let damp = (-DAMPING * dt).exp();
+    self.velocity[0] *= damp;
+    self.velocity[1] *= damp;
+
+    let speed = (self.velocity[0] * self.velocity[0] + self.velocity[1] * self.velocity[1]).sqrt();
+    if speed > MAX_SPEED {
+      let scale = MAX_SPEED / speed;
+      self.velocity[0] *= scale;
+      self.velocity[1] *= scale;
+    }
+
+    self.offset[0] += self.velocity[0] * dt;
+    self.offset[1] += self.velocity[1] * dt;
+  }
+}
+
+/// Apply a terminal mouse event to gravity interaction state.
+pub fn handle_mouse_event(
+  mouse: MouseEvent,
+  gravity: &mut GravityState,
+  terminal_size: (u16, u16),
+) {
+  let width = terminal_size.0.max(1) as f32;
+  let height = terminal_size.1.max(1) as f32;
+  let x = mouse.column as f32 / width;
+  let y = mouse.row as f32 / height;
+
+  match mouse.kind {
+    MouseEventKind::Down(MouseButton::Left) => {
+      gravity.set_mouse_position(x, y);
+      gravity.set_mouse_pressed(true);
+    }
+    MouseEventKind::Up(MouseButton::Left) => {
+      gravity.set_mouse_position(x, y);
+      gravity.set_mouse_pressed(false);
+    }
+    MouseEventKind::Drag(MouseButton::Left) | MouseEventKind::Moved => {
+      gravity.set_mouse_position(x, y);
+    }
+    _ => {}
+  }
+}
+
+/// Net vertical acceleration after mouse fight.
+fn net_vertical_accel(
+  gravity: f32,
+  mouse_fight: f32,
+  mouse_active: bool,
+  mouse_pressed: bool,
+) -> f32 {
+  let gravity = gravity.max(0.0);
+  let gravity_accel = gravity * GRAVITY_ACCEL_SCALE;
+  if gravity_accel <= 0.0 {
+    return 0.0;
+  }
+  if !mouse_active {
+    return gravity_accel;
+  }
+
+  let fight_strength = mouse_fight.clamp(0.0, 1.0);
+  let press_boost = if mouse_pressed { 1.0 } else { 0.65 };
+  let requested_fight = gravity_accel * MOUSE_FIGHT_CAP * fight_strength * press_boost;
+  let min_net_accel = gravity_accel * (1.0 - MOUSE_FIGHT_CAP);
+  (gravity_accel - requested_fight).max(min_net_accel)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn mouse_cannot_overpower_gravity() {
+    let gravity = 1.0;
+    let with_mouse = net_vertical_accel(gravity, 1.0, true, true);
+    let without = net_vertical_accel(gravity, 1.0, false, false);
+
+    assert!(without > 0.0);
+    assert!(with_mouse > 0.0);
+    assert!(with_mouse < without);
+    assert!(
+      with_mouse + f32::EPSILON >= without * (1.0 - MOUSE_FIGHT_CAP),
+      "mouse fight exceeded cap: {with_mouse} vs floor {}",
+      without * (1.0 - MOUSE_FIGHT_CAP)
+    );
+  }
+
+  #[test]
+  fn inactive_mouse_leaves_full_gravity() {
+    let accel = net_vertical_accel(0.8, 1.0, false, false);
+    assert!((accel - 0.8 * GRAVITY_ACCEL_SCALE).abs() < 1e-5);
+  }
+
+  #[test]
+  fn update_increases_downward_offset_over_time() {
+    let mut state = GravityState::default();
+    for _ in 0..30 {
+      state.update(1.0, 0.7, 1.0 / 60.0);
+    }
+    assert!(state.offset[1] > 0.0);
+    assert!(state.velocity[1] > 0.0);
+  }
+
+  #[test]
+  fn pressed_mouse_slows_but_does_not_reverse_fall() {
+    let mut falling = GravityState::default();
+    let mut fighting = GravityState::default();
+    fighting.set_mouse_position(0.5, 0.2);
+    fighting.set_mouse_pressed(true);
+
+    for _ in 0..45 {
+      falling.update(1.0, 1.0, 1.0 / 60.0);
+      fighting.update(1.0, 1.0, 1.0 / 60.0);
+    }
+
+    assert!(fighting.offset[1] > 0.0);
+    assert!(fighting.offset[1] < falling.offset[1]);
+    assert!(fighting.velocity[1] > 0.0);
+  }
+
+  #[test]
+  fn mouse_move_updates_normalized_position() {
+    let mut gravity = GravityState::default();
+    handle_mouse_event(
+      MouseEvent {
+        kind: MouseEventKind::Moved,
+        column: 40,
+        row: 12,
+        modifiers: crossterm::event::KeyModifiers::NONE,
+      },
+      &mut gravity,
+      (80, 24),
+    );
+
+    assert!(gravity.mouse_active);
+    assert!((gravity.mouse[0] - 0.5).abs() < 1e-5);
+    assert!((gravity.mouse[1] - 0.5).abs() < 1e-5);
+  }
+}

--- a/src/app/gravity.rs
+++ b/src/app/gravity.rs
@@ -54,9 +54,9 @@ impl GravityState {
     }
   }
 
-  /// Effective mouse influence sent to the shader (0 = idle).
-  pub fn shader_mouse_influence(&self, mouse_fight: f32) -> f32 {
-    if !self.mouse_active {
+  /// Effective mouse influence sent to the shader (0 = idle or gravity off).
+  pub fn shader_mouse_influence(&self, gravity: f32, mouse_fight: f32) -> f32 {
+    if !self.mouse_active || gravity <= 0.0001 {
       return 0.0;
     }
 
@@ -93,12 +93,7 @@ impl GravityState {
     }
 
     let mut accel_x = 0.0;
-    let accel_y = net_vertical_accel(
-      gravity,
-      mouse_fight,
-      self.mouse_active,
-      self.mouse_pressed,
-    );
+    let accel_y = net_vertical_accel(gravity, mouse_fight, self.mouse_active, self.mouse_pressed);
 
     if self.mouse_active {
       let press_boost = if self.mouse_pressed { 1.0 } else { 0.65 };
@@ -209,6 +204,21 @@ mod tests {
     }
     assert!(state.offset[1] > 0.0);
     assert!(state.velocity[1] > 0.0);
+  }
+
+  #[test]
+  fn gravity_zero_ignores_mouse_for_shader_influence_and_fall() {
+    let mut state = GravityState::default();
+    state.set_mouse_position(0.2, 0.2);
+    state.set_mouse_pressed(true);
+
+    for _ in 0..30 {
+      state.update(0.0, 1.0, 1.0 / 60.0);
+    }
+
+    assert_eq!(state.shader_mouse_influence(0.0, 1.0), 0.0);
+    assert!(state.offset[1].abs() < 0.02);
+    assert!(state.velocity[1].abs() < 0.05);
   }
 
   #[test]

--- a/src/app/gravity.rs
+++ b/src/app/gravity.rs
@@ -5,6 +5,8 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 
 /// Max fraction of gravity acceleration the mouse may cancel (must stay < 1).
 const MOUSE_FIGHT_CAP: f32 = 0.75;
+/// Fight strength when the cursor is active but the button is not held.
+const HOVER_FIGHT_FACTOR: f32 = 0.65;
 /// UV units / s² per unit of the `gravity` parameter.
 const GRAVITY_ACCEL_SCALE: f32 = 0.45;
 /// Horizontal pull toward the mouse cursor (scaled by gravity).
@@ -64,7 +66,7 @@ impl GravityState {
     if self.mouse_pressed {
       base
     } else {
-      base * 0.65
+      base * HOVER_FIGHT_FACTOR
     }
   }
 
@@ -96,7 +98,11 @@ impl GravityState {
     let accel_y = net_vertical_accel(gravity, mouse_fight, self.mouse_active, self.mouse_pressed);
 
     if self.mouse_active {
-      let press_boost = if self.mouse_pressed { 1.0 } else { 0.65 };
+      let press_boost = if self.mouse_pressed {
+        1.0
+      } else {
+        HOVER_FIGHT_FACTOR
+      };
       // Horizontal tug toward the cursor; strength scales with gravity.
       accel_x += (self.mouse[0] - 0.5) * HORIZONTAL_PULL * gravity * press_boost;
     }
@@ -164,7 +170,11 @@ fn net_vertical_accel(
   }
 
   let fight_strength = mouse_fight.clamp(0.0, 1.0);
-  let press_boost = if mouse_pressed { 1.0 } else { 0.65 };
+  let press_boost = if mouse_pressed {
+    1.0
+  } else {
+    HOVER_FIGHT_FACTOR
+  };
   let requested_fight = gravity_accel * MOUSE_FIGHT_CAP * fight_strength * press_boost;
   let min_net_accel = gravity_accel * (1.0 - MOUSE_FIGHT_CAP);
   (gravity_accel - requested_fight).max(min_net_accel)

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -7,31 +7,39 @@ use chroma::{
 };
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
-use super::DebugLog;
+use super::{
+  gravity::{self, GravityState},
+  DebugLog,
+};
 
 const EFFECT_TYPE_COUNT: u32 = 7;
 const FIRST_ACTIVE_EFFECT_TYPE: u32 = 2;
 const PARAMETER_STEP: f32 = 0.1;
 
-/// Handle keyboard input events
+/// Handle keyboard and mouse input events
 pub fn handle_input(
   params: &mut ShaderParams,
   converter: &mut AsciiConverter,
+  gravity: &mut GravityState,
+  terminal_size: (u16, u16),
   running: &mut bool,
   debug_log: &mut DebugLog,
 ) -> Result<()> {
-  if !event::poll(Duration::from_millis(0))? {
-    return Ok(());
-  }
-
-  if let Event::Key(KeyEvent {
-    code,
-    modifiers,
-    kind: KeyEventKind::Press,
-    ..
-  }) = event::read()?
-  {
-    handle_key_press(code, modifiers, params, converter, running, debug_log)?;
+  while event::poll(Duration::from_millis(0))? {
+    match event::read()? {
+      Event::Key(KeyEvent {
+        code,
+        modifiers,
+        kind: KeyEventKind::Press,
+        ..
+      }) => {
+        handle_key_press(code, modifiers, params, converter, running, debug_log)?;
+      }
+      Event::Mouse(mouse) => {
+        gravity::handle_mouse_event(mouse, gravity, terminal_size);
+      }
+      _ => {}
+    }
   }
 
   Ok(())
@@ -124,6 +132,10 @@ fn handle_key_press(
     }
     KeyCode::Char('[') => params.adjust_scale(-PARAMETER_STEP),
     KeyCode::Char(']') => params.adjust_scale(PARAMETER_STEP),
+
+    // Gravity
+    KeyCode::Char('g') => params.adjust_gravity(PARAMETER_STEP),
+    KeyCode::Char('G') => params.adjust_gravity(-PARAMETER_STEP),
 
     // Pattern selection
     KeyCode::Char('t') | KeyCode::Char('T') => {
@@ -596,6 +608,37 @@ mod tests {
 
     assert_eq!(params.effect_type, 6);
     assert_eq!(params.effect_time, 12.0);
+  }
+
+  #[test]
+  fn test_gravity_keys_adjust_strength() {
+    let mut params = ShaderParams {
+      gravity: 0.5,
+      ..ShaderParams::default()
+    };
+    let mut converter = AsciiConverter::new(AsciiPalette::from(params.palette), true);
+    let mut running = true;
+    let mut debug_log = test_debug_log();
+
+    invoke_key(
+      KeyCode::Char('g'),
+      KeyModifiers::NONE,
+      &mut params,
+      &mut converter,
+      &mut running,
+      &mut debug_log,
+    );
+    assert!((params.gravity - 0.6).abs() < 1e-5);
+
+    invoke_key(
+      KeyCode::Char('G'),
+      KeyModifiers::NONE,
+      &mut params,
+      &mut converter,
+      &mut running,
+      &mut debug_log,
+    );
+    assert!((params.gravity - 0.5).abs() < 1e-5);
   }
 
   #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ macro_rules! debug_logln {
 
 mod audio;
 mod config_watcher;
+mod gravity;
 mod input;
 mod rendering;
 mod status_bar;
@@ -21,7 +22,7 @@ use chroma::{
   debug::{frame_logging_enabled, DebugLog},
   params::ShaderParams,
   render::{RenderedCell, StreamFormat},
-  shader::{ShaderPipeline, ShaderUniforms},
+  shader::{InteractionUniforms, ShaderPipeline, ShaderUniforms},
 };
 use crossterm::terminal;
 
@@ -114,6 +115,7 @@ pub struct App {
   status_bar_audio_hold_remaining: f32,
   status_bar_audio_flow_elapsed: f32,
   status_bar_audio_production_elapsed: f32,
+  gravity: gravity::GravityState,
 }
 
 pub struct AppOptions {
@@ -221,6 +223,7 @@ impl App {
       status_bar_audio_hold_remaining: 0.0,
       status_bar_audio_flow_elapsed: 0.0,
       status_bar_audio_production_elapsed: 0.0,
+      gravity: gravity::GravityState::default(),
     })
   }
 
@@ -276,6 +279,10 @@ impl App {
 
     self.params.update_time(delta_time);
 
+    self
+      .gravity
+      .update(self.params.gravity, self.params.mouse_fight, delta_time);
+
     let features = audio::update_audio_reactive(
       &mut self.params,
       &self.audio_capture,
@@ -310,7 +317,12 @@ impl App {
 
   /// Render current frame
   fn render(&mut self) -> Result<()> {
-    let uniforms = ShaderUniforms::from_params(&self.params);
+    let interaction = InteractionUniforms {
+      gravity_offset: self.gravity.offset,
+      mouse_position: self.gravity.mouse,
+      mouse_influence: self.gravity.shader_mouse_influence(self.params.mouse_fight),
+    };
+    let uniforms = ShaderUniforms::from_params_with_interaction(&self.params, interaction);
 
     if frame_logging_enabled() {
       debug_logln!(
@@ -483,6 +495,8 @@ impl App {
         input::handle_input(
           &mut self.params,
           &mut self.converter,
+          &mut self.gravity,
+          self.last_terminal_size,
           &mut self.running,
           &mut self.debug_log,
         )?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -320,7 +320,9 @@ impl App {
     let interaction = InteractionUniforms {
       gravity_offset: self.gravity.offset,
       mouse_position: self.gravity.mouse,
-      mouse_influence: self.gravity.shader_mouse_influence(self.params.mouse_fight),
+      mouse_influence: self
+        .gravity
+        .shader_mouse_influence(self.params.gravity, self.params.mouse_fight),
     };
     let uniforms = ShaderUniforms::from_params_with_interaction(&self.params, interaction);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -186,6 +186,14 @@ pub struct CliArgs {
   #[arg(short = 'v', long, value_name = "FLOAT")]
   pub vignette: Option<f32>,
 
+  /// Downward gravity for the pattern scroll. 0 = off. Mouse can fight it but not cancel it. Range: 0.0-2.0
+  #[arg(long, value_name = "FLOAT")]
+  pub gravity: Option<f32>,
+
+  /// How strongly mouse input fights gravity (still cannot overpower it). Range: 0.0-1.0
+  #[arg(long, value_name = "FLOAT")]
+  pub mouse_fight: Option<f32>,
+
   /// Terminal background color in hex format (e.g. FF0000, #00FF00, ABC, #123456). Sets the background color for the terminal cells/window
   #[arg(long, value_name = "HEX")]
   pub background_color: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,12 @@ fn apply_cli_overrides(params: &mut ShaderParams, cli: &CliArgs) -> Result<()> {
   if let Some(v) = cli.vignette {
     params.vignette = v;
   }
+  if let Some(v) = cli.gravity {
+    params.gravity = v;
+  }
+  if let Some(v) = cli.mouse_fight {
+    params.mouse_fight = v;
+  }
 
   // Background color (parse hex) - for terminal cell background
   if let Some(ref hex_color) = cli.background_color {

--- a/src/params/randomizer.rs
+++ b/src/params/randomizer.rs
@@ -124,6 +124,14 @@ pub fn randomize_with_rng(params: &mut ShaderParams, rng: &mut impl Rng) {
   params.mid_influence = rng.random_range(0.2..=0.6);
   params.treble_influence = rng.random_range(0.1..=0.5);
   params.beat_sensitivity = rng.random_range(0.5..=2.0);
+
+  // Occasional gravity so randomization can discover the effect
+  if rng.random_bool(0.25) {
+    params.gravity = rng.random_range(0.2..=1.2);
+    params.mouse_fight = rng.random_range(0.4..=1.0);
+  } else {
+    params.gravity = 0.0;
+  }
 }
 
 #[cfg(test)]

--- a/src/params/randomizer.rs
+++ b/src/params/randomizer.rs
@@ -131,6 +131,7 @@ pub fn randomize_with_rng(params: &mut ShaderParams, rng: &mut impl Rng) {
     params.mouse_fight = rng.random_range(0.4..=1.0);
   } else {
     params.gravity = 0.0;
+    params.mouse_fight = 0.7;
   }
 }
 

--- a/src/params/shader_params.rs
+++ b/src/params/shader_params.rs
@@ -62,6 +62,11 @@ pub struct ShaderParams {
   pub beat_distortion_time: f32,
   pub beat_distortion_strength: f32,
   pub beat_zoom_strength: f32,
+
+  /// Downward gravity strength for UV scroll. 0 = off. Range: 0.0-2.0
+  pub gravity: f32,
+  /// How strongly the mouse may fight gravity (never enough to cancel it). Range: 0.0-1.0
+  pub mouse_fight: f32,
 }
 
 impl Default for ShaderParams {
@@ -117,6 +122,9 @@ impl Default for ShaderParams {
       beat_distortion_time: -100.0,
       beat_distortion_strength: 0.85,
       beat_zoom_strength: 0.7,
+
+      gravity: 0.0,
+      mouse_fight: 0.7,
     }
   }
 }
@@ -230,6 +238,9 @@ impl ShaderParams {
     self.mid_influence = self.mid_influence.clamp(0.0, 1.0);
     self.treble_influence = self.treble_influence.clamp(0.0, 1.0);
     self.beat_sensitivity = self.beat_sensitivity.clamp(0.1, 3.0);
+
+    self.gravity = self.gravity.clamp(0.0, 2.0);
+    self.mouse_fight = self.mouse_fight.clamp(0.0, 1.0);
   }
 
   pub fn adjust_frequency(&mut self, delta: f32) {
@@ -246,6 +257,14 @@ impl ShaderParams {
 
   pub fn adjust_scale(&mut self, delta: f32) {
     Self::adjust_clamped(&mut self.scale, delta, 0.1, 5.0);
+  }
+
+  pub fn adjust_gravity(&mut self, delta: f32) {
+    Self::adjust_clamped(&mut self.gravity, delta, 0.0, 2.0);
+  }
+
+  pub fn adjust_mouse_fight(&mut self, delta: f32) {
+    Self::adjust_clamped(&mut self.mouse_fight, delta, 0.0, 1.0);
   }
 
   pub fn adjust_brightness(&mut self, delta: f32) {

--- a/src/shader/mod.rs
+++ b/src/shader/mod.rs
@@ -2,4 +2,4 @@ pub mod pipeline;
 pub mod uniforms;
 
 pub use pipeline::ShaderPipeline;
-pub use uniforms::ShaderUniforms;
+pub use uniforms::{InteractionUniforms, ShaderUniforms};

--- a/src/shader/uniforms.rs
+++ b/src/shader/uniforms.rs
@@ -2,6 +2,13 @@ use bytemuck::{Pod, Zeroable};
 
 use crate::params::ShaderParams;
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct InteractionUniforms {
+  pub gravity_offset: [f32; 2],
+  pub mouse_position: [f32; 2],
+  pub mouse_influence: f32,
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct ShaderUniforms {
@@ -39,13 +46,27 @@ pub struct ShaderUniforms {
   pub beat_distortion_time: f32,
   pub beat_distortion_strength: f32,
   pub beat_zoom_strength: f32,
-  _padding2: [u32; 3], // Need 12 bytes padding to align vec3 to 16-byte boundary
+  pub gravity: f32,
+
+  pub gravity_offset: [f32; 2],
+  pub mouse_position: [f32; 2],
+
+  pub mouse_influence: f32,
+  // Align background_tint (vec3) to a 16-byte boundary.
+  _padding2: u32,
   pub background_tint: [f32; 3],
   _padding3: u32,
 }
 
 impl ShaderUniforms {
   pub fn from_params(params: &ShaderParams) -> Self {
+    Self::from_params_with_interaction(params, InteractionUniforms::default())
+  }
+
+  pub fn from_params_with_interaction(
+    params: &ShaderParams,
+    interaction: InteractionUniforms,
+  ) -> Self {
     Self {
       time: params.time,
       _padding1: 0,
@@ -84,7 +105,13 @@ impl ShaderUniforms {
       beat_distortion_time: params.beat_distortion_time,
       beat_distortion_strength: params.beat_distortion_strength,
       beat_zoom_strength: params.beat_zoom_strength,
-      _padding2: [0; 3],
+      gravity: params.gravity,
+
+      gravity_offset: interaction.gravity_offset,
+      mouse_position: interaction.mouse_position,
+
+      mouse_influence: interaction.mouse_influence,
+      _padding2: 0,
       background_tint: [
         params.background_tint_r,
         params.background_tint_g,
@@ -110,6 +137,7 @@ mod tests {
     assert_eq!(uniforms.time, 0.0);
     assert_eq!(uniforms.resolution[0], 80.0);
     assert_eq!(uniforms.resolution[1], 24.0);
+    assert_eq!(uniforms.gravity, 0.0);
   }
 
   #[test]
@@ -143,13 +171,20 @@ mod tests {
       beat_distortion_time: 6.5,
       beat_distortion_strength: 0.95,
       beat_zoom_strength: 0.55,
+      gravity: 0.8,
+      mouse_fight: 0.7,
       background_tint_r: 0.1,
       background_tint_g: 0.2,
       background_tint_b: 0.3,
       ..ShaderParams::default()
     };
 
-    let uniforms = ShaderUniforms::from_params(&params);
+    let interaction = InteractionUniforms {
+      gravity_offset: [0.15, 0.25],
+      mouse_position: [0.3, 0.4],
+      mouse_influence: 0.55,
+    };
+    let uniforms = ShaderUniforms::from_params_with_interaction(&params, interaction);
 
     assert_eq!(uniforms.time, 12.5);
     assert_eq!(uniforms.resolution, [132.0, 41.0]);
@@ -178,12 +213,16 @@ mod tests {
     assert_eq!(uniforms.beat_distortion_time, 6.5);
     assert_eq!(uniforms.beat_distortion_strength, 0.95);
     assert_eq!(uniforms.beat_zoom_strength, 0.55);
+    assert_eq!(uniforms.gravity, 0.8);
+    assert_eq!(uniforms.gravity_offset, [0.15, 0.25]);
+    assert_eq!(uniforms.mouse_position, [0.3, 0.4]);
+    assert_eq!(uniforms.mouse_influence, 0.55);
     assert_eq!(uniforms.background_tint, [0.1, 0.2, 0.3]);
   }
 
   #[test]
   fn test_uniforms_layout_matches_expected_alignment() {
-    assert_eq!(mem::size_of::<ShaderUniforms>(), 144);
+    assert_eq!(mem::size_of::<ShaderUniforms>(), 160);
     assert_eq!(mem::align_of::<ShaderUniforms>(), 4);
     assert_eq!(mem::size_of::<ShaderUniforms>() % 16, 0);
   }

--- a/src/shader_common/gravity.wgsl
+++ b/src/shader_common/gravity.wgsl
@@ -1,0 +1,16 @@
+// Gravity scroll + mouse warp that fights the fall locally without canceling it.
+
+fn apply_gravity_and_mouse(position: vec2<f32>) -> vec2<f32> {
+    var warped = position + uniforms.gravity_offset;
+
+    let influence = uniforms.mouse_influence;
+    if influence > 0.001 && uniforms.gravity > 0.001 {
+        let to_mouse = uniforms.mouse_position - position;
+        let distance_sq = dot(to_mouse, to_mouse);
+        // Local tug toward the cursor; kept subtle so global gravity still dominates.
+        let pull = influence * 0.07 * exp(-distance_sq * 10.0);
+        warped = warped + to_mouse * pull;
+    }
+
+    return warped;
+}

--- a/src/shader_common/main.wgsl
+++ b/src/shader_common/main.wgsl
@@ -69,8 +69,9 @@ fn pattern_position(position: vec2<f32>, pattern_type: u32) -> vec2<f32> {
 }
 
 fn plasma_effect(position: vec2<f32>, time: f32) -> vec3<f32> {
-    // Apply beat zoom first
-    var processed_position = apply_beat_zoom(position, time);
+    // Gravity scroll + capped mouse tug, then beat zoom / distortion
+    var processed_position = apply_gravity_and_mouse(position);
+    processed_position = apply_beat_zoom(processed_position, time);
     
     // Then apply beat-reactive distortion to position for visual pop effect
     processed_position = apply_beat_distortion(processed_position, time);

--- a/src/shader_common/uniforms.wgsl
+++ b/src/shader_common/uniforms.wgsl
@@ -28,6 +28,10 @@ struct Uniforms {
     beat_distortion_time: f32,
     beat_distortion_strength: f32,
     beat_zoom_strength: f32,
+    gravity: f32,
+    gravity_offset: vec2<f32>,
+    mouse_position: vec2<f32>,
+    mouse_influence: f32,
     background_tint: vec3<f32>,
 }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 use crossterm::{cursor, event, execute, terminal};
 
 fn write_setup_sequence<W: Write>(writer: &mut W) -> Result<()> {
+  // Mouse capture stays on for the whole interactive session so live `g`/`G`
+  // gravity adjustments can receive pointer input without restarting.
   execute!(
     writer,
     terminal::EnterAlternateScreen,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,21 +1,27 @@
 use std::io::{stdout, Write};
 
 use anyhow::Result;
-use crossterm::{cursor, execute, terminal};
+use crossterm::{cursor, event, execute, terminal};
 
 fn write_setup_sequence<W: Write>(writer: &mut W) -> Result<()> {
   execute!(
     writer,
     terminal::EnterAlternateScreen,
     cursor::Hide,
-    terminal::Clear(terminal::ClearType::All)
+    terminal::Clear(terminal::ClearType::All),
+    event::EnableMouseCapture
   )?;
 
   Ok(())
 }
 
 fn write_cleanup_sequence<W: Write>(writer: &mut W) -> Result<()> {
-  execute!(writer, cursor::Show, terminal::LeaveAlternateScreen)?;
+  execute!(
+    writer,
+    event::DisableMouseCapture,
+    cursor::Show,
+    terminal::LeaveAlternateScreen
+  )?;
 
   Ok(())
 }
@@ -44,24 +50,39 @@ mod tests {
   use super::*;
 
   #[test]
-  fn test_setup_sequence_writes_alternate_screen_hide_and_clear() {
+  fn test_setup_sequence_writes_alternate_screen_hide_clear_and_mouse() {
     let mut output = Vec::new();
 
     write_setup_sequence(&mut output).unwrap();
 
     let text = String::from_utf8(output).unwrap();
 
-    assert_eq!(text, "\u{1b}[?1049h\u{1b}[?25l\u{1b}[2J");
+    assert!(text.contains("\u{1b}[?1049h"));
+    assert!(text.contains("\u{1b}[?25l"));
+    assert!(text.contains("\u{1b}[2J"));
+    assert!(
+      text.contains("\u{1b}[?1000h")
+        || text.contains("\u{1b}[?1002h")
+        || text.contains("\u{1b}[?1003h")
+        || text.contains("\u{1b}[?1006h")
+    );
   }
 
   #[test]
-  fn test_cleanup_sequence_writes_show_and_leave_alternate_screen() {
+  fn test_cleanup_sequence_disables_mouse_shows_cursor_and_leaves_alt_screen() {
     let mut output = Vec::new();
 
     write_cleanup_sequence(&mut output).unwrap();
 
     let text = String::from_utf8(output).unwrap();
 
-    assert_eq!(text, "\u{1b}[?25h\u{1b}[?1049l");
+    assert!(text.contains("\u{1b}[?25h"));
+    assert!(text.contains("\u{1b}[?1049l"));
+    assert!(
+      text.contains("\u{1b}[?1000l")
+        || text.contains("\u{1b}[?1002l")
+        || text.contains("\u{1b}[?1003l")
+        || text.contains("\u{1b}[?1006l")
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Adds downward pattern gravity (`--gravity`, `g`/`G`) with mouse interaction that can resist the fall but cannot cancel it (75% fight cap).
- Wires gravity through params, CLI/config, shader uniforms, WGSL UV transform, terminal mouse capture, randomization, and docs.
- Keeps `gravity=0` as the default so existing stream/preset/audio behavior stays unchanged.

## Why
Interactive sessions needed a gravity effect where the pointer can fight the downward pull without overpowering it.

## What changed
- New `src/app/gravity.rs` physics + mouse handling and `src/shader_common/gravity.wgsl` UV warp
- Uniform layout extended (160 bytes) and synced across Rust/WGSL/custom shader example
- Interactive terminal enables mouse capture; stream mode remains non-interactive
- Docs: `README.md`, `notes/CONTROLS.md`, `notes/USAGE.md`

## Removed
- None (cleanup only consolidated the hover fight factor constant)

## Docs / ADR / Plan / Epic
- No ADR/plan/epic for this ad-hoc feature
- User docs updated; no architecture/roadmap/CHANGELOG docs in this repo

## Verification
### Implementation readiness
- [x] `full-review` Round 3 — APPROVE — IMPLEMENTATION_READY (A PASS, B PASS, C N/A)
- [x] `clean-up-slop` — completed this session
- [x] `cargo fmt --all -- --check` — PASS (stable; nightly rustfmt options warn outside nix)
- [x] `cargo clippy --all-targets -- -D warnings` — PASS
- [x] `cargo test` — PASS (all suites; 3 GPU render tests ignored as expected)
- [ ] Nightly `cargo fmt` via nix flake — not available on this host
- [ ] Ignored GPU `render_test` — hardware gate not run locally

### Cutover-owned production verification
- None (local terminal visualizer; no cutover plan)

## Notes
- Mouse fight is hard-capped at 75% of gravity acceleration so net force stays downward.
- Interactive sessions always enable mouse capture so live `g`/`G` can receive pointer input.


Made with [Cursor](https://cursor.com)